### PR TITLE
 Add return state info with errors of create func

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -23,6 +23,6 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1
 github.com/rancher/rke                           30d8c8a30ff421abc293eafaa233bce34b72d218
 github.com/rancher/norman                        0557aa4ff31a3a0f007dcb1b684894f23cda390c
 github.com/rancher/types                         522fc4d7b1af7ecea4caec2399a9338d27ab814b
-github.com/rancher/kontainer-engine              447b7766d6aa1f15986c182eb2d7b7e97ef3678e
+github.com/rancher/kontainer-engine              0544470a0e37edf70909790e63c653fed318fbd6
 
 github.com/tencentcloud/tencentcloud-sdk-go      1a03559bc3f7cc76eb4aaccdad246ca365362031  https://github.com/guangbochen/tencentcloud-sdk-go.git

--- a/vendor/github.com/rancher/kontainer-engine/drivers/options/options.go
+++ b/vendor/github.com/rancher/kontainer-engine/drivers/options/options.go
@@ -11,6 +11,13 @@ func GetValueFromDriverOptions(driverOptions *types.DriverOptions, optionType st
 			}
 		}
 		return int64(0)
+	case types.IntPointerType:
+		for _, key := range keys {
+			if value, ok := driverOptions.IntOptions[key]; ok {
+				return &value
+			}
+		}
+		return nil
 	case types.StringType:
 		for _, key := range keys {
 			if value, ok := driverOptions.StringOptions[key]; ok {

--- a/vendor/github.com/rancher/kontainer-engine/drivers/util/utils.go
+++ b/vendor/github.com/rancher/kontainer-engine/drivers/util/utils.go
@@ -22,8 +22,6 @@ const (
 	kontainerEngine           = "kontainer-engine"
 	oldClusterRoleBindingName = "netes-default-clusterRoleBinding"
 	newClusterRoleBindingName = "system-netes-default-clusterRoleBinding"
-
-	cattleNodeAgentLableSelector = "app=cattle-agent"
 )
 
 // GenerateServiceAccountToken generate a serviceAccountToken for clusterAdmin given a rest clientset
@@ -143,8 +141,4 @@ func ConvertToRkeConfig(config string) (v3.RancherKubernetesEngineConfig, error)
 		return rkeConfig, err
 	}
 	return rkeConfig, nil
-}
-
-func RestartCattleNodeAgent(clientset kubernetes.Interface) error {
-	return clientset.CoreV1().Pods(cattleNamespace).DeleteCollection(&metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: cattleNodeAgentLableSelector})
 }

--- a/vendor/github.com/rancher/kontainer-engine/types/types.go
+++ b/vendor/github.com/rancher/kontainer-engine/types/types.go
@@ -13,6 +13,8 @@ const (
 	BoolPointerType = "boolPtr"
 	// IntType is the type for int flag
 	IntType = "int"
+	// IntPointerType flag should be used if the int value can be nil
+	IntPointerType = "intPtr"
 	// StringSliceType is the type for stringSlice flag
 	StringSliceType = "stringSlice"
 )


### PR DESCRIPTION
**Problem:**
When using improper config e.g, AMI then attempting to delete the cluster, deletion displays as completed in UI, but does not complete in the hosted cloud provider.

**Solution:**
Nil was being returned as the cluster state when an error was encountered. This led to an invalid state that caused errors and disrupted the cluster deletion process. The creation process now returns the state along with the error.