### PR TITLE
Add update cluster interface to the TKE driver

### DIFF
--- a/tencentcloud/ccs/client.go
+++ b/tencentcloud/ccs/client.go
@@ -187,3 +187,111 @@ func (c *Client) OperateClusterVip(request *OperateClusterVipRequest) (response 
 	err = c.Send(request, response)
 	return
 }
+
+// NewAddClusterInstancesRequest defines driver cluster add instances request
+func NewAddClusterInstancesRequest() (request *AddClusterInstancesRequest) {
+	request = &AddClusterInstancesRequest{
+		BaseRequest: &tchttp.BaseRequest{},
+	}
+	request.Init().WithApiInfo("cis", apiVersion, "AddClusterInstances")
+	return
+}
+
+// NewAddClusterInstancesResponse defines driver cluster add instances response
+func NewAddClusterInstancesResponse() (response *AddClusterInstancesResponse) {
+	response = &AddClusterInstancesResponse{
+		BaseResponse: &tchttp.BaseResponse{},
+	}
+	return
+}
+
+// AddClusterInstances adds new cluster instances to the cluster
+func (c *Client) AddClusterInstances(request *AddClusterInstancesRequest) (response *AddClusterInstancesResponse, err error) {
+	if request == nil {
+		request = NewAddClusterInstancesRequest()
+	}
+	response = NewAddClusterInstancesResponse()
+	err = c.Send(request, response)
+	return
+}
+
+// NewModifyClusterAttributesRequest defines driver modify cluster attributes request
+func NewModifyClusterAttributesRequest() (request *ModifyClusterAttributesRequest) {
+	request = &ModifyClusterAttributesRequest{
+		BaseRequest: &tchttp.BaseRequest{},
+	}
+	request.Init().WithApiInfo("cis", apiVersion, "ModifyClusterAttributes")
+	return
+}
+
+// NewModifyClusterAttributesResponse defines driver modify cluster attributes response
+func NewModifyClusterAttributesResponse() (response *ModifyClusterAttributesResponse) {
+	response = &ModifyClusterAttributesResponse{
+		BaseResponse: &tchttp.BaseResponse{},
+	}
+	return
+}
+
+// ModifyClusterAttributes update cluster attributes
+func (c *Client) ModifyClusterAttributes(request *ModifyClusterAttributesRequest) (response *ModifyClusterAttributesResponse, err error) {
+	if request == nil {
+		request = NewModifyClusterAttributesRequest()
+	}
+	response = NewModifyClusterAttributesResponse()
+	err = c.Send(request, response)
+	return
+}
+
+// NewModifyProjectIDRequest defines driver modify cluster attributes request
+func NewModifyProjectIDRequest() (request *ModifyProjectIDRequest) {
+	request = &ModifyProjectIDRequest{
+		BaseRequest: &tchttp.BaseRequest{},
+	}
+	request.Init().WithApiInfo("cis", apiVersion, "ModifyProjectId")
+	return
+}
+
+// NewModifyProjectIDResponse defines driver modify cluster attributes response
+func NewModifyProjectIDResponse() (response *ModifyProjectIDResponse) {
+	response = &ModifyProjectIDResponse{
+		BaseResponse: &tchttp.BaseResponse{},
+	}
+	return
+}
+
+// ModifyProjectID update cluster attributes
+func (c *Client) ModifyProjectID(request *ModifyProjectIDRequest) (response *ModifyProjectIDResponse, err error) {
+	if request == nil {
+		request = NewModifyProjectIDRequest()
+	}
+	response = NewModifyProjectIDResponse()
+	err = c.Send(request, response)
+	return
+}
+
+// NewDeleteClusterInstancesRequest defines driver cluster delete instances request
+func NewDeleteClusterInstancesRequest() (request *DeleteClusterInstancesRequest) {
+	request = &DeleteClusterInstancesRequest{
+		BaseRequest: &tchttp.BaseRequest{},
+	}
+	request.Init().WithApiInfo("cis", apiVersion, "DeleteClusterInstances")
+	return
+}
+
+// NewDeleteClusterInstancesResponse defines driver cluster delete instances response
+func NewDeleteClusterInstancesResponse() (response *DeleteClusterInstancesResponse) {
+	response = &DeleteClusterInstancesResponse{
+		BaseResponse: &tchttp.BaseResponse{},
+	}
+	return
+}
+
+// DeleteClusterInstances removes cluster instances by id
+func (c *Client) DeleteClusterInstances(request *DeleteClusterInstancesRequest) (response *DeleteClusterInstancesResponse, err error) {
+	if request == nil {
+		request = NewDeleteClusterInstancesRequest()
+	}
+	response = NewDeleteClusterInstancesResponse()
+	err = c.Send(request, response)
+	return
+}

--- a/tencentcloud/ccs/models.go
+++ b/tencentcloud/ccs/models.go
@@ -432,3 +432,229 @@ func (r *OperateClusterVipResponse) ToJSONString() string {
 func (r *OperateClusterVipResponse) FromJSONString(s string) error {
 	return json.Unmarshal([]byte(s), &r)
 }
+
+// AddClusterInstancesRequest defines the addClusterInstances request
+type AddClusterInstancesRequest struct {
+	*tchttp.BaseRequest
+	// The name of the cluster
+	ClusterID         string `json:"clusterId" name:"clusterId"`
+	ExpandInstanceNum int64  `json:"expandInstanceNum" name:"expandInstanceNum"`
+
+	// The description of the cluster
+	ClusterDesc string `json:"clusterDesc" name:"clusterDesc"`
+	// The zone id of the cluster
+	ZoneID string `json:"zoneId" name:"zoneId"`
+	// The number of nodes purchased, up to 100
+	GoodsNum int64 `json:"goodsNum" name:"goodsNum"`
+	// CPU core number
+	CPU int64 `json:"cpu" name:"cpu"`
+	// Memory size (GB)
+	Mem int64 `json:"mem" name:"mem"`
+	// System name, Centos7.2x86_64 or ubuntu16.04.1 LTSx86_64, all nodes in the cluster use this system,
+	// the extension node will also automatically use this system (*required)
+	OsName string `json:"osName" name:"osName"`
+	// System name, Centos7.2x86_64 or ubuntu16.04.1 LTSx86_64, all nodes in the cluster use this system,
+	// the extension node will also automatically use this system (*required)
+	InstanceType string `json:"instanceType" name:"instanceType"`
+	// See CVM Instance Configuration for details . Default: S1.SMALL1
+	CvmType string `json:"cvmType" name:"cvmType"`
+	// The annual renewal fee for the annual subscription, default to NOTIFY_AND_AUTO_RENEW
+	RenewFlag string `json:"renewFlag" name:"renewFlag"`
+	// Type of bandwidth
+	// PayByMonth vm: PayByMonth, PayByTraffic,
+	// PayByHour vm: PayByHour, PayByTraffic
+	BandwidthType string `json:"bandwidthType" name:"bandwidthType"`
+	// Public network bandwidth (Mbps), when the traffic is charged for the public network bandwidth peak
+	Bandwidth int64 `json:"bandwidth" name:"bandwidth"`
+	// Whether to open the public network IP, 0: not open 1: open
+	WanIP int64 `json:"wanIp" name:"wanIp"`
+	// Subnet ID
+	SubnetID string `json:"subnetId" name:"subnetId"`
+	// Whether it is a public network gateway
+	// 0: non-public network gateway
+	// 1: public network gateway
+	IsVpcGateway int64 `json:"isVpcGateway" name:"isVpcGateway"`
+	// system disk size. linux system adjustment range is 20 - 50g, step size is 1
+	RootSize int64 `json:"rootSize" name:"rootSize"`
+	// System disk type. System disk type restrictions are detailed in the CVM instance configuration.
+	// default value of the SSD cloud drive : CLOUD_BASIC.
+	RootType string `json:"rootType" name:"rootType"`
+	// Data disk size (GB)
+	StorageSize int64 `json:"storageSize" name:"storageSize"`
+	// Data disk type
+	StorageType string `json:"storageType" name:"storageType"`
+	// Node password
+	Password string `json:"password" name:"password"`
+	// Key id
+	KeyID string `json:"keyId" name:"keyId"`
+	// The annual subscription period of the annual subscription month, unit month. This parameter is required when cvmType is PayByMonth
+	Period int64 `json:"period" name:"period"`
+	// Security group ID, default does not bind any security groups, please fill out the inquiry list of security groups sgId field interface returned
+	SgID string `json:"sgId" name:"sgId"`
+	// Base64-encoded user script, which is executed after the k8s component is run. The user is required to guarantee the reentrant and retry logic of the script.
+	UserScript string `json:"userScript" name:"userScript"`
+}
+
+// ToJSONString defines request to json format
+func (r *AddClusterInstancesRequest) ToJSONString() string {
+	b, _ := json.Marshal(r)
+	return string(b)
+}
+
+// FromJSONString defines request from json format
+func (r *AddClusterInstancesRequest) FromJSONString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// AddClusterInstancesResponse defines the add cluster instances response
+type AddClusterInstancesResponse struct {
+	*tchttp.BaseResponse
+	// Cluster data
+	Data struct {
+		RequestID   string   `json:"requestId" name:"requestId"`
+		InstanceIDs []string `json:"instanceIds" name:"instanceIds"`
+	} `json:"data"`
+	// Public error code. 0 means success, other values indicates failure
+	Code int64 `json:"code" name:"code"`
+	// Module error message description, related to the interface
+	Message string `json:"message" name:"message"`
+	// Service side error code. Returns Success when successful,
+	// and returns the reason for a specific business error when an error occurs
+	CodeDesc string `json:"codeDesc" name:"codeDesc"`
+}
+
+// ToJSONString defines response to json format
+func (r *AddClusterInstancesResponse) ToJSONString() string {
+	b, _ := json.Marshal(r)
+	return string(b)
+}
+
+// FromJSONString defines response from json format
+func (r *AddClusterInstancesResponse) FromJSONString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// ModifyClusterAttributesRequest defines the modify cluster attributes request
+type ModifyClusterAttributesRequest struct {
+	*tchttp.BaseRequest
+	ClusterID   string `json:"clusterId" name:"clusterId"`
+	ClusterName string `json:"clusterName" name:"clusterName"`
+	ClusterDesc string `json:"clusterDesc" name:"clusterDesc"`
+}
+
+// ToJSONString defines request to json format
+func (r *ModifyClusterAttributesRequest) ToJSONString() string {
+	b, _ := json.Marshal(r)
+	return string(b)
+}
+
+// FromJSONString defines request from json format
+func (r *ModifyClusterAttributesRequest) FromJSONString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// ModifyClusterAttributesResponse defines the response
+type ModifyClusterAttributesResponse struct {
+	*tchttp.BaseResponse
+	// Public error code. 0 means success, other values indicates failure
+	Code int64 `json:"code" name:"code"`
+	// Module error message description, related to the interface
+	Message string `json:"message" name:"message"`
+	// Service side error code. Returns Success when successful,
+	// and returns the reason for a specific business error when an error occurs
+	CodeDesc string `json:"codeDesc" name:"codeDesc"`
+}
+
+// ToJSONString defines request to json format
+func (r *ModifyClusterAttributesResponse) ToJSONString() string {
+	b, _ := json.Marshal(r)
+	return string(b)
+}
+
+// FromJSONString defines request from json format
+func (r *ModifyClusterAttributesResponse) FromJSONString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// ModifyProjectIDRequest defines the modify project ID request
+type ModifyProjectIDRequest struct {
+	*tchttp.BaseRequest
+	ClusterID string `json:"clusterId" name:"clusterId"`
+	ProjectID int64  `json:"projectId" name:"projectId"`
+}
+
+// ToJSONString defines request to json format
+func (r *ModifyProjectIDRequest) ToJSONString() string {
+	b, _ := json.Marshal(r)
+	return string(b)
+}
+
+// FromJSONString defines request from json format
+func (r *ModifyProjectIDRequest) FromJSONString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// ModifyProjectIDResponse defines the response
+type ModifyProjectIDResponse struct {
+	*tchttp.BaseResponse
+	// Public error code. 0 means success, other values indicates failure
+	Code int64 `json:"code" name:"code"`
+	// Module error message description, related to the interface
+	Message string `json:"message" name:"message"`
+	// Service side error code. Returns Success when successful,
+	// and returns the reason for a specific business error when an error occurs
+	CodeDesc string `json:"codeDesc" name:"codeDesc"`
+}
+
+// ToJSONString defines request to json format
+func (r *ModifyProjectIDResponse) ToJSONString() string {
+	b, _ := json.Marshal(r)
+	return string(b)
+}
+
+// FromJSONString defines request from json format
+func (r *ModifyProjectIDResponse) FromJSONString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// DeleteClusterInstancesRequest defines the delete cluster instances request
+type DeleteClusterInstancesRequest struct {
+	*tchttp.BaseRequest
+	ClusterID      string   `json:"clusterId" name:"clusterId"`
+	InstanceIDs    []string `json:"instanceIds" name:"instanceIds"`
+	NodeDeleteMode string   `json:"nodeDeleteMode" name:"nodeDeleteMode"`
+}
+
+// ToJSONString defines response to json format
+func (r *DeleteClusterInstancesRequest) ToJSONString() string {
+	b, _ := json.Marshal(r)
+	return string(b)
+}
+
+// FromJSONString defines response from json format
+func (r *DeleteClusterInstancesRequest) FromJSONString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}
+
+// DeleteClusterInstancesResponse defines the delete cluster instances response
+type DeleteClusterInstancesResponse struct {
+	*tchttp.BaseResponse
+	// Public error code. 0 means success, other values indicates failure
+	Code int64 `json:"code" name:"code"`
+	// Module error message description, related to the interface
+	Message string `json:"message" name:"message"`
+	// Service side error code. Returns Success when successful,
+	// and returns the reason for a specific business error when an error occurs
+	CodeDesc string `json:"codeDesc" name:"codeDesc"`
+}
+
+// ToJSONString defines response to json format
+func (r *DeleteClusterInstancesResponse) ToJSONString() string {
+	b, _ := json.Marshal(r)
+	return string(b)
+}
+
+// FromJSONString defines response from json format
+func (r *DeleteClusterInstancesResponse) FromJSONString(s string) error {
+	return json.Unmarshal([]byte(s), &r)
+}


### PR DESCRIPTION
**Problem:**
Support edit TKE cluster and allowing add more worker node.

**Solution:**
Added update cluster interface to the TKE driver, and the configurable parameters are listed as below:

| Variable  | Type   | Is_required  | Default  | Description  |
|---|---|---|---|---|
| secretId  | string | yes | N/A |  the secret id |
| secretKey  | string | yes | N/A |  the secret key |
| driverName  | string | yes | tencentkubernetesengine |  the secret key |
| nodeCount  |  int | yes | N/A | The number of total nodes purchased. |
| instanceType  |  string | no | S2.MEDIUM4  |  CVM Instance type |
| storageSize | int | no | 50  | Data disk size (GB), the step size is 10 |
| rootSize| int | no | 50 | System disk size. Linux system adjustment range is 20 - 50G, step size is 1  |
| clusterName |  string  | no  | none   |  cluster name  |
| clusterDesc  |  string | no | none  |  cluster description |
| projectId  | int  | no | 0  | modify the projectId that the k8s cluster belongs to in tencentCloud. |
| bandwidthType | string | no | PayByTraffic  | PayByTraffic or PayByHour  |
| bandwidth|  int  | no | 1 | Public network bandwidth (Mbps), when the traffic is charged for the public network bandwidth peak  |
| wanIp  | int | no | 1 |  the cluster master occupies the IP of a VPC subnet |
| isVpcGateway | int | no | 0 |  Whether it is a public network gateway, network gateway only in public with a public IP, and in order to work properly when under private network |

**Issues:**
https://github.com/rancher/rancher/issues/17175
